### PR TITLE
Amend docker compose file to allow make scripts running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,19 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
   db:
     image: "postgres:alpine"
     restart: always
+    container_name: postgres
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
       POSTGRES_DB: "go_restful"
+    volumes:
+      - ./testdata:/testdata
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s


### PR DESCRIPTION
Can now run

`make migrate`

and

`make testdata`

when using docker-compose to run the containers

